### PR TITLE
allow custom remote ssh port

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ The local port for the forwarding.
 
 *Default:* a random port between `49151` and `65535`
 
+### port
+
+The ssh port on the destination server.
+
+*Default:* `22`
+
 ### privateKeyPath
 
 The local path to your ssh private key.

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
       name: options.name,
       defaultConfig: {
           dstPort: 6379,
+          port: 22,
           dstHost: 'localhost',
           srcPort: function() {
             var range = MAX_PORT_NUMBER - MIN_PORT_NUMBER + 1;
@@ -41,6 +42,7 @@ module.exports = {
 
         var sshConfig = {
           host: this.readConfig('host'),
+          port: this.readConfig('port'),
           dstPort: this.readConfig('dstPort'),
           dstHost: this.readConfig('dstHost'),
           username: this.readConfig('username'),

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -106,7 +106,7 @@ describe('ssh-tunnel plugin', function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 4);
+        assert.equal(messages.length, 5);
       });
 
       it('adds default config to the config object', function() {


### PR DESCRIPTION
previously it was only possible to access remote hosts at port `22`.
