### PR TITLE
Defaults to ssh-agent instead of privateKeyPath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+---
+language: node_js
+node_js:
+  - "0.12"
+
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+
+before_install:
+  - "npm config set spin false"
+  - "npm install -g npm@^2"
+
+install:
+  - npm install -g bower
+  - npm install
+  - bower install
+
+script:
+  - npm test

--- a/README.md
+++ b/README.md
@@ -62,19 +62,19 @@ For detailed information on how configuration of plugins works, please refer to 
 
 ### username (`required`)
 
-The user for the ssh connection
+The user for the ssh connection.
 
 *Default:* `undefined`
 
 ### host (`required`)
 
-The server to connect to
+The server to connect to.
 
 *Default:* `undefined`
 
 ### dstPort
 
-The port to forward from the server
+The port to forward from the server.
 
 *Default:* `6379`
 
@@ -86,15 +86,21 @@ The host to forward to on the destination server.
 
 ### srcPort
 
-The local port for the forwarding
+The local port for the forwarding.
 
 *Default:* a random port between `49151` and `65535`
 
 ### privateKeyPath
 
-The local path to your ssh private key
+The local path to your ssh private key.
 
-*Default:* `~/.ssh/id_rsa`
+*Default:* null
+
+### password
+
+Authorization string for the ssh connection.
+
+*Default:* null
 
 ### tunnelClient
 
@@ -102,15 +108,41 @@ The client used to create the ssh tunnel. This allows the user the ability to us
 
 *Default:* the tunnel provided by `tunnel-ssh`
 
+## Authorization
+
+ember-cli-deploy-ssh-tunnel uses the [tunnel-ssh](https://github.com/Finanzchef24-GmbH/tunnel-ssh) module to provide the SSH tunnel. Two options exist to configure tunnel-ssh from ember-cli-deploy-ssh-tunnel: `privateKeyPath` and `password`. By default, we assume you have created a public and private key and added it to ssh-agent as described in the [default GitHub setup](https://help.github.com/articles/generating-ssh-keys/). 
+
+If no authentication information is delivered to tunnel-ssh, it will [default to using ssh-agent](https://github.com/Finanzchef24-GmbH/tunnel-ssh), so it will default to using the default id_rsa keys generated as described in the GitHub article. This includes password-protected SSH keys. If you would like to use a different SSH key, set the `privateKeyPath` option:
+
+```js
+ENV['ssh-tunnel'] = {
+  username: 'yourname',
+  host: 'yourserver',
+  privateKeyPath: '~/.ssh/another_key_rsa'
+};
+```
+
+If you just want to use a password to tunnel, you can specify that as an option (we recommend using environmental variables in an .env file):
+
+```js
+ENV['ssh-tunnel'] = {
+  username: 'yourname',
+  host: 'yourserver',
+  password: process.env.SSH_PASSWORD
+};
+```
+
+NOTE: at this time, this plugin does not support setting a path to `privateKeyPath` to a key that has been encrypted with a password.
+
 ## Running Tests
 
-- `npm test`
-
-[1]: http://ember-cli.github.io/ember-cli-deploy/plugins "Plugin Documentation"
-
+1. `npm install`
+2. `npm test`
 
 ## Thanks to:
 
 @lukemelia and @achambers and the other folks from the ember-cli-deploy project.
 
 @tim-evans for the original implementation in [ember-deploy-redis](https://github.com/LevelbossMike/ember-deploy-redis)
+
+[1]: http://ember-cli.github.io/ember-cli-deploy/plugins "Plugin Documentation"

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 /* jshint node: true */
 'use strict';
 
-var Promise    = require('ember-cli/lib/ext/promise');
-var fs         = require('fs');
+var Promise   = require('ember-cli/lib/ext/promise');
+var fs        = require('fs');
 var tunnelSsh = require('tunnel-ssh');
-var untildify  = require('untildify');
+var untildify = require('untildify');
 
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 
@@ -24,7 +24,6 @@ module.exports = {
             var range = MAX_PORT_NUMBER - MIN_PORT_NUMBER + 1;
             return Math.floor(Math.random() * range) + MIN_PORT_NUMBER;
           },
-          privateKeyPath: '~/.ssh/id_rsa',
           tunnelClient: function(context) {
             // if you want to provide your own ssh client to be used instead of one from this plugin
             return context.tunnelClient || tunnelSsh;
@@ -45,18 +44,21 @@ module.exports = {
           dstPort: this.readConfig('dstPort'),
           dstHost: this.readConfig('dstHost'),
           username: this.readConfig('username'),
-          localPort: srcPort,
-          privateKey: this.readConfig('privateKeyPath')
+          localPort: srcPort
         };
 
-        if (sshConfig.privateKey) {
-          sshConfig.privateKey = fs.readFileSync(untildify(sshConfig.privateKey));
-        }
-
+        var password = this.readConfig('password');
+        var privateKey = this.readConfig('privateKeyPath');
         var tunnel = this.readConfig('tunnelClient');
 
-        return new Promise(function (resolve, reject) {
-          var sshTunnel = tunnel(sshConfig, function (error /*, result */) {
+        if (password) {
+          sshConfig.password = password;
+        } else if (privateKey) {
+          sshConfig.privateKey = fs.readFileSync(untildify(privateKey));
+        }
+
+        return new Promise(function(resolve, reject) {
+          var sshTunnel = tunnel(sshConfig, function(error /*, result */) {
             if (error) {
               reject(error);
             } else {

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -21,7 +21,13 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "require",
+    "describe",
+    "before",
+    "beforeEach",
+    "it",
+    "process"
   ],
   "node": false,
   "browser": false,

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,3 +1,4 @@
+/*jshint globalstrict: true*/
 'use strict';
 
 var glob = require('glob');

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,9 +1,7 @@
+/*jshint globalstrict: true*/
 'use strict';
 
-var Promise = require('ember-cli/lib/ext/promise');
 var assert  = require('ember-cli/tests/helpers/assert');
-var fs      = require('fs');
-var path    = require('path');
 
 describe('ssh-tunnel plugin', function() {
   var subject, mockUi;
@@ -77,7 +75,7 @@ describe('ssh-tunnel plugin', function() {
           config: config
         };
         plugin.beforeHook(context);
-        assert.throws(function(error){
+        assert.throws(function(){
           plugin.configure(context);
         });
         var messages = mockUi.messages.reduce(function(previous, current) {
@@ -117,7 +115,7 @@ describe('ssh-tunnel plugin', function() {
             host: 'example.com',
             username: 'ghedamat'
           }
-        }
+        };
         context = {
           ui: mockUi,
           config: config
@@ -147,11 +145,11 @@ describe('ssh-tunnel plugin', function() {
             username: 'example',
             password: 'secret'
           }
-        }
+        };
         context = {
           ui: mockUi,
           config: config
-        }
+        };
         plugin.beforeHook(context);
         plugin.configure(context);
         assert.isDefined(config['ssh-tunnel'].password);
@@ -165,11 +163,11 @@ describe('ssh-tunnel plugin', function() {
             username: 'example',
             privateKeyPath: '~/.ssh/id_rsa'
           }
-        }
+        };
         context = {
           ui: mockUi,
           config: config
-        }
+        };
         plugin.beforeHook(context);
         plugin.configure(context);
         assert.isUndefined(config['ssh-tunnel'].password);
@@ -180,8 +178,7 @@ describe('ssh-tunnel plugin', function() {
   });
 
   describe('setup hook', function() {
-    var plugin;
-    var context;
+    var plugin, context;
 
     beforeEach(function() {
       plugin = subject.createDeployPlugin({
@@ -222,8 +219,7 @@ describe('ssh-tunnel plugin', function() {
   });
 
   describe('teardown hook', function() {
-    var plugin;
-    var context;
+    var plugin, context;
 
     beforeEach(function() {
       plugin = subject.createDeployPlugin({
@@ -250,7 +246,7 @@ describe('ssh-tunnel plugin', function() {
         }
       };
 
-      var result = plugin.teardown(context);
+      plugin.teardown(context);
     });
   });
 });


### PR DESCRIPTION
As discussed on slack, tunnel-ssh defaults to ssh-agent use if you aren't using a password or privateKeyPath. Since ssh-agent will default to id_rsa key, this PR presume that most folks'll be happy with using that. You can opt in to a different key path with the old variable. Also added support for ssh password passed to tunnel-ssh. Basic test coverage provided.
